### PR TITLE
Add preview support for PKCS#8 and PKCS#1 object

### DIFF
--- a/src/lib/openssl.ts
+++ b/src/lib/openssl.ts
@@ -199,6 +199,12 @@ function genSelfSignedCert(data:any): Promise<any> {
     });
 }
 
+function parsePkey(text:string):string {
+    return execSync(`${opensslExec} pkey -text -noout`, {
+        input: text
+    }).toString('utf-8');
+}
+
 function parsePem(text:string):string {
     return execSync(`${opensslExec} x509 -text -noout`, {
         input: text
@@ -218,6 +224,7 @@ const openssl = {
     genPrivKey: genPrivKey,
     genSelfSignedCert: genSelfSignedCert,
     genP12: genP12,
+    parsePkey: parsePkey,
     parsePem: parsePem,
     parseCsr: parseCsr
 };

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -28,6 +28,8 @@ export class OpenSSLTextDocumentContentProvider implements vscode.TextDocumentCo
                 return openssl.parsePem(text);
             } else if (text.startsWith('-----BEGIN CERTIFICATE REQUEST-----') || text.startsWith('-----BEGIN NEW CERTIFICATE REQUEST-----')) {
                 return openssl.parseCsr(text);			
+            } else if (text.startsWith('-----BEGIN PRIVATE KEY-----') || text.startsWith('-----BEGIN RSA PRIVATE KEY-----')) {
+                return openssl.parsePkey(text);
 			}
             return 'Preview not available';
         }


### PR DESCRIPTION
Sometimes it may be convenient to preview the content of the secret key. (e.g. to check the algorithm or check whether the key is consistent with the CSR).

I try to add preview support for two major private key formats (I think :D) in this PR. 