### PR TITLE
feat: add inline OpenSSL CodeLens feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For Windows users: in order to use OpenSSL through Windows Subsystem for Linux (
 ![Generate Key and Csr](images/privkey.gif)
 
 
-### Generate RSA Private Key and Certificate Signing Request 
+### Generate RSA Private Key and Certificate Signing Request
 
 
 ![Generate Key and Csr](images/keycsr.gif)
@@ -71,6 +71,7 @@ At the time of writing this README there are no known issues.
 
 * Omar de Mingo
 * Fabrizio Balsamo
+* Justin J. Novack (@jnovack)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1453 +1,1777 @@
 {
     "name": "opensslutils",
-    "version": "1.0.1",
-    "lockfileVersion": 1,
+    "version": "1.1.1",
+    "lockfileVersion": 3,
     "requires": true,
-    "dependencies": {
-        "@types/mocha": {
+    "packages": {
+        "": {
+            "name": "opensslutils",
+            "version": "1.1.1",
+            "hasInstallScript": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "devDependencies": {
+                "@types/mocha": "^2.2.42",
+                "@types/node": "^7.0.43",
+                "@types/vscode": "^1.23.0",
+                "tslint": "^5.8.0",
+                "typescript": "^2.6.1",
+                "vscode": "^1.1.6"
+            },
+            "engines": {
+                "vscode": "^1.23.0"
+            }
+        },
+        "node_modules/@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
             "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
             "dev": true
         },
-        "@types/node": {
+        "node_modules/@types/node": {
             "version": "7.0.65",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.65.tgz",
             "integrity": "sha512-iUdyWWikcQnGvIZnYh5ZxnxeREykndA9+iGdo068NGNutibWknDjmmNMq/8cnS1eaTCcgqJsPsFppw3XJWNlUg==",
             "dev": true
         },
-        "ajv": {
+        "node_modules/@types/vscode": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.23.0.tgz",
+            "integrity": "sha512-gMIEQTtt84M2PglQ8pmuanc9I8TZIHkK9bWz8teandxZX5o+gGGdbt0bfA5OMtotDqf3Ni+iRW5YaZCJFzJ07A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ajv": {
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
-            "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+            "dependencies": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
-        "ansi-cyan": {
+        "node_modules/ansi-cyan": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
             "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "ansi-red": {
+        "node_modules/ansi-red": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
             "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "ansi-regex": {
+        "node_modules/ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "ansi-styles": {
+        "node_modules/ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "ansi-wrap": {
+        "node_modules/ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "argparse": {
+        "node_modules/argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
-            "requires": {
-                "sprintf-js": "1.0.3"
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
             }
         },
-        "arr-diff": {
+        "node_modules/arr-diff": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
-            "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+            "dependencies": {
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "arr-flatten": {
+        "node_modules/arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "arr-union": {
+        "node_modules/arr-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
             "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "array-differ": {
+        "node_modules/array-differ": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "array-slice": {
+        "node_modules/array-slice": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
             "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "array-union": {
+        "node_modules/array-union": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
-            "requires": {
-                "array-uniq": "1.0.3"
+            "dependencies": {
+                "array-uniq": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "array-uniq": {
+        "node_modules/array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "array-unique": {
+        "node_modules/array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "arrify": {
+        "node_modules/arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "asn1": {
+        "node_modules/asn1": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
             "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
             "dev": true
         },
-        "assert-plus": {
+        "node_modules/assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
         },
-        "asynckit": {
+        "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
-        "aws-sign2": {
+        "node_modules/aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "aws4": {
+        "node_modules/aws4": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
             "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
             "dev": true
         },
-        "babel-code-frame": {
+        "node_modules/babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
             "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                }
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
-        "balanced-match": {
+        "node_modules/babel-code-frame/node_modules/chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
-        "bcrypt-pbkdf": {
+        "node_modules/bcrypt-pbkdf": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "dev": true,
             "optional": true,
-            "requires": {
-                "tweetnacl": "0.14.5"
+            "dependencies": {
+                "tweetnacl": "^0.14.3"
             }
         },
-        "block-stream": {
+        "node_modules/block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
-            "requires": {
-                "inherits": "2.0.3"
+            "dependencies": {
+                "inherits": "~2.0.0"
+            },
+            "engines": {
+                "node": "0.4 || >=0.5.8"
             }
         },
-        "brace-expansion": {
+        "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "requires": {
-                "balanced-match": "1.0.0",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-        "braces": {
+        "node_modules/braces": {
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
-            "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+            "dependencies": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "browser-stdout": {
+        "node_modules/browser-stdout": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
-        "buffer-crc32": {
+        "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "buffer-from": {
+        "node_modules/buffer-from": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
             "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
             "dev": true
         },
-        "builtin-modules": {
+        "node_modules/builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "caseless": {
+        "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
-        "chalk": {
+        "node_modules/chalk": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
-            "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
-            },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
-        "clone": {
+        "node_modules/chalk/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/clone": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
             "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "clone-buffer": {
+        "node_modules/clone-buffer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
             "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
-        "clone-stats": {
+        "node_modules/clone-stats": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
             "dev": true
         },
-        "cloneable-readable": {
+        "node_modules/cloneable-readable": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
-            "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
-        "co": {
+        "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
         },
-        "color-convert": {
+        "node_modules/color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
+            "dependencies": {
+                "color-name": "^1.1.1"
             }
         },
-        "color-name": {
+        "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
-        "combined-stream": {
+        "node_modules/combined-stream": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
-            "requires": {
-                "delayed-stream": "1.0.0"
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
-        "commander": {
+        "node_modules/commander": {
             "version": "2.15.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
             "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
             "dev": true
         },
-        "concat-map": {
+        "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "convert-source-map": {
+        "node_modules/convert-source-map": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
-        "core-util-is": {
+        "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
-        "dashdash": {
+        "node_modules/dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0"
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
             }
         },
-        "debug": {
+        "node_modules/debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ms": "2.0.0"
             }
         },
-        "deep-assign": {
+        "node_modules/deep-assign": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
-            "requires": {
-                "is-obj": "1.0.1"
+            "dependencies": {
+                "is-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "delayed-stream": {
+        "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
-        "diff": {
+        "node_modules/diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
         },
-        "duplexer": {
+        "node_modules/duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
-        "duplexify": {
+        "node_modules/duplexify": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
-            "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+            "dependencies": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
-        "ecc-jsbn": {
+        "node_modules/ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "dev": true,
             "optional": true,
-            "requires": {
-                "jsbn": "0.1.1"
+            "dependencies": {
+                "jsbn": "~0.1.0"
             }
         },
-        "end-of-stream": {
+        "node_modules/end-of-stream": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
-            "requires": {
-                "once": "1.4.0"
+            "dependencies": {
+                "once": "^1.4.0"
             }
         },
-        "escape-string-regexp": {
+        "node_modules/escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
-        "esprima": {
+        "node_modules/esprima": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
             "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-            "dev": true
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
         },
-        "esutils": {
+        "node_modules/esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "event-stream": {
+        "node_modules/event-stream": {
             "version": "3.3.4",
             "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
-            "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
-        "expand-brackets": {
+        "node_modules/expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
-            "requires": {
-                "is-posix-bracket": "0.1.1"
+            "dependencies": {
+                "is-posix-bracket": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "expand-range": {
+        "node_modules/expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
-            "requires": {
-                "fill-range": "2.2.4"
+            "dependencies": {
+                "fill-range": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "extend": {
+        "node_modules/extend": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
             "dev": true
         },
-        "extend-shallow": {
+        "node_modules/extend-shallow": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
-            "requires": {
-                "kind-of": "1.1.0"
+            "dependencies": {
+                "kind-of": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "extglob": {
+        "node_modules/extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
-            "requires": {
-                "is-extglob": "1.0.0"
-            },
             "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                }
+                "is-extglob": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "extsprintf": {
+        "node_modules/extglob/node_modules/is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ]
         },
-        "fast-deep-equal": {
+        "node_modules/fast-deep-equal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
             "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
             "dev": true
         },
-        "fast-json-stable-stringify": {
+        "node_modules/fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
-        "fd-slicer": {
+        "node_modules/fd-slicer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
-            "requires": {
-                "pend": "1.2.0"
+            "dependencies": {
+                "pend": "~1.2.0"
             }
         },
-        "filename-regex": {
+        "node_modules/filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "fill-range": {
+        "node_modules/fill-range": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
-            "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+            "dependencies": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "first-chunk-stream": {
+        "node_modules/first-chunk-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
             "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "for-in": {
+        "node_modules/for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "for-own": {
+        "node_modules/for-own": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
-            "requires": {
-                "for-in": "1.0.2"
+            "dependencies": {
+                "for-in": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "forever-agent": {
+        "node_modules/forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "form-data": {
+        "node_modules/form-data": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
-            "requires": {
-                "asynckit": "0.4.0",
+            "dependencies": {
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
             }
         },
-        "from": {
+        "node_modules/from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
         },
-        "fs.realpath": {
+        "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "fstream": {
+        "node_modules/fstream": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "deprecated": "This package is no longer supported.",
             "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "engines": {
+                "node": ">=0.6"
             }
         },
-        "getpass": {
+        "node_modules/getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0"
+            "dependencies": {
+                "assert-plus": "^1.0.0"
             }
         },
-        "glob": {
+        "node_modules/glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
-            "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "glob-base": {
+        "node_modules/glob-base": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
             "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "glob-parent": {
+        "node_modules/glob-base/node_modules/glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^2.0.0"
+            }
+        },
+        "node_modules/glob-base/node_modules/is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/glob-base/node_modules/is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
-            "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+            "dependencies": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
-        "glob-stream": {
+        "node_modules/glob-stream": {
             "version": "5.3.5",
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
-            "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
-            },
             "dependencies": {
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
-        "graceful-fs": {
+        "node_modules/glob-stream/node_modules/glob": {
+            "version": "5.0.15",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "dependencies": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/glob-stream/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "node_modules/glob-stream/node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/glob-stream/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "node_modules/glob-stream/node_modules/through2": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
+            }
+        },
+        "node_modules/graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
-        "growl": {
+        "node_modules/growl": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
             "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=4.x"
+            }
         },
-        "gulp-chmod": {
+        "node_modules/gulp-chmod": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
-            "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+            "dependencies": {
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
-        "gulp-filter": {
+        "node_modules/gulp-filter": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
-            "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+            "dependencies": {
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
-        "gulp-gunzip": {
+        "node_modules/gulp-gunzip": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
-            "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
-            },
             "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             }
         },
-        "gulp-remote-src-vscode": {
+        "node_modules/gulp-gunzip/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "node_modules/gulp-gunzip/node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/gulp-gunzip/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "node_modules/gulp-gunzip/node_modules/through2": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
+            }
+        },
+        "node_modules/gulp-remote-src-vscode": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
-            },
             "dependencies": {
-                "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
-                    }
-                }
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             }
         },
-        "gulp-sourcemaps": {
+        "node_modules/gulp-remote-src-vscode/node_modules/clone": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/gulp-remote-src-vscode/node_modules/clone-stats": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
+        },
+        "node_modules/gulp-remote-src-vscode/node_modules/vinyl": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/gulp-sourcemaps": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
-            "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
-            },
             "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             }
         },
-        "gulp-symdest": {
+        "node_modules/gulp-sourcemaps/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/replace-ext": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/vinyl": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
+                "replace-ext": "0.0.1"
+            },
+            "engines": {
+                "node": ">= 0.9"
+            }
+        },
+        "node_modules/gulp-symdest": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+            "dependencies": {
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
-        "gulp-untar": {
+        "node_modules/gulp-untar": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
-            },
             "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             }
         },
-        "gulp-vinyl-zip": {
+        "node_modules/gulp-untar/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/gulp-untar/node_modules/replace-ext": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gulp-untar/node_modules/vinyl": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
+                "replace-ext": "0.0.1"
+            },
+            "engines": {
+                "node": ">= 0.9"
+            }
+        },
+        "node_modules/gulp-vinyl-zip": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.2",
-                "yazl": "2.4.3"
-            },
             "dependencies": {
-                "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "queue": {
-                    "version": "4.4.2",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
-                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
-                    }
-                }
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             }
         },
-        "har-schema": {
+        "node_modules/gulp-vinyl-zip/node_modules/clone": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/gulp-vinyl-zip/node_modules/clone-stats": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
+        },
+        "node_modules/gulp-vinyl-zip/node_modules/queue": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
+            "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "~2.0.0"
+            }
+        },
+        "node_modules/gulp-vinyl-zip/node_modules/vinyl": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
         },
-        "har-validator": {
+        "node_modules/har-validator": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "deprecated": "this library is no longer supported",
             "dev": true,
-            "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+            "dependencies": {
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
-        "has-ansi": {
+        "node_modules/has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
-            "requires": {
-                "ansi-regex": "2.1.1"
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "has-flag": {
+        "node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
         },
-        "he": {
+        "node_modules/he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
+            "dev": true,
+            "bin": {
+                "he": "bin/he"
+            }
         },
-        "http-signature": {
+        "node_modules/http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.8",
+                "npm": ">=1.3.7"
             }
         },
-        "inflight": {
+        "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
-            "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
-        "inherits": {
+        "node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
-        "is": {
+        "node_modules/is": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
             "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "is-buffer": {
+        "node_modules/is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
-        "is-dotfile": {
+        "node_modules/is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
             "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-equal-shallow": {
+        "node_modules/is-equal-shallow": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
+            "dependencies": {
+                "is-primitive": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "is-extendable": {
+        "node_modules/is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-extglob": {
+        "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-glob": {
+        "node_modules/is-glob": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
-            "requires": {
-                "is-extglob": "2.1.1"
+            "dependencies": {
+                "is-extglob": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "is-number": {
+        "node_modules/is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
-            "requires": {
-                "kind-of": "3.2.2"
-            },
             "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
+                "kind-of": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "is-obj": {
+        "node_modules/is-number/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "dependencies": {
+                "is-buffer": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-posix-bracket": {
+        "node_modules/is-posix-bracket": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
             "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-primitive": {
+        "node_modules/is-primitive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-stream": {
+        "node_modules/is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "is-typedarray": {
+        "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
-        "is-utf8": {
+        "node_modules/is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
-        "is-valid-glob": {
+        "node_modules/is-valid-glob": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
             "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "isarray": {
+        "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
-        "isobject": {
+        "node_modules/isobject": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "isarray": "1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "isstream": {
+        "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
-        "js-tokens": {
+        "node_modules/js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
-        "js-yaml": {
+        "node_modules/js-yaml": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
-            "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
-        "jsbn": {
+        "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true,
             "optional": true
         },
-        "json-schema": {
+        "node_modules/json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
-        "json-schema-traverse": {
+        "node_modules/json-schema-traverse": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
             "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
             "dev": true
         },
-        "json-stable-stringify": {
+        "node_modules/json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
-            "requires": {
-                "jsonify": "0.0.0"
+            "dependencies": {
+                "jsonify": "~0.0.0"
             }
         },
-        "json-stringify-safe": {
+        "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
-        "jsonify": {
+        "node_modules/jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "jsprim": {
+        "node_modules/jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
             "dev": true,
-            "requires": {
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
             }
         },
-        "kind-of": {
+        "node_modules/kind-of": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
             "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "lazystream": {
+        "node_modules/lazystream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
+            "dependencies": {
+                "readable-stream": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.6.3"
             }
         },
-        "lodash.isequal": {
+        "node_modules/lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "dev": true
         },
-        "map-stream": {
+        "node_modules/map-stream": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
-        "math-random": {
+        "node_modules/math-random": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
             "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
             "dev": true
         },
-        "merge-stream": {
+        "node_modules/merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
+            "dependencies": {
+                "readable-stream": "^2.0.1"
             }
         },
-        "micromatch": {
+        "node_modules/micromatch": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
-            "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
-            },
             "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "mime-db": {
+        "node_modules/micromatch/node_modules/arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true,
+            "dependencies": {
+                "arr-flatten": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/micromatch/node_modules/is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/micromatch/node_modules/is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/micromatch/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "dependencies": {
+                "is-buffer": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/mime-db": {
             "version": "1.33.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
             "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "mime-types": {
+        "node_modules/mime-types": {
             "version": "2.1.18",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
-            "requires": {
-                "mime-db": "1.33.0"
+            "dependencies": {
+                "mime-db": "~1.33.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "minimatch": {
+        "node_modules/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
-            "requires": {
-                "brace-expansion": "1.1.11"
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "minimist": {
+        "node_modules/minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
-        "mkdirp": {
+        "node_modules/mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
             }
         },
-        "mocha": {
+        "node_modules/mocha": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
             "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "browser-stdout": "1.3.0",
                 "commander": "2.11.0",
                 "debug": "3.1.0",
@@ -1459,789 +1783,964 @@
                 "mkdirp": "0.5.1",
                 "supports-color": "4.4.0"
             },
-            "dependencies": {
-                "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-                    "dev": true
-                },
-                "diff": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
-        "ms": {
+        "node_modules/mocha/node_modules/commander": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true
+        },
+        "node_modules/mocha/node_modules/diff": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/mocha/node_modules/has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/mocha/node_modules/supports-color": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
-        "multimatch": {
+        "node_modules/multimatch": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+            "dependencies": {
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "node.extend": {
+        "node_modules/node.extend": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
-            "requires": {
-                "is": "3.2.1"
+            "dependencies": {
+                "is": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
-        "normalize-path": {
+        "node_modules/normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
-            "requires": {
-                "remove-trailing-separator": "1.1.0"
+            "dependencies": {
+                "remove-trailing-separator": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "oauth-sign": {
+        "node_modules/oauth-sign": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
         },
-        "object-assign": {
+        "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "object.omit": {
+        "node_modules/object.omit": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
-            "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+            "dependencies": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "once": {
+        "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
-            "requires": {
-                "wrappy": "1.0.2"
+            "dependencies": {
+                "wrappy": "1"
             }
         },
-        "ordered-read-streams": {
+        "node_modules/ordered-read-streams": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
-            "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
+            "dependencies": {
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
-        "parse-glob": {
+        "node_modules/parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
-            "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
             "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "path-dirname": {
+        "node_modules/parse-glob/node_modules/is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/parse-glob/node_modules/is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
-        "path-is-absolute": {
+        "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "path-parse": {
+        "node_modules/path-parse": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
-        "pause-stream": {
+        "node_modules/pause-stream": {
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
-            "requires": {
-                "through": "2.3.8"
+            "dependencies": {
+                "through": "~2.3"
             }
         },
-        "pend": {
+        "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
             "dev": true
         },
-        "performance-now": {
+        "node_modules/performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
-        "plugin-error": {
+        "node_modules/plugin-error": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
-            "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+            "dependencies": {
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "preserve": {
+        "node_modules/preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "process-nextick-args": {
+        "node_modules/process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
             "dev": true
         },
-        "punycode": {
+        "node_modules/punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
-        "qs": {
+        "node_modules/qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
         },
-        "querystringify": {
+        "node_modules/querystringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
             "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
             "dev": true
         },
-        "queue": {
+        "node_modules/queue": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
-            "requires": {
-                "inherits": "2.0.3"
+            "dependencies": {
+                "inherits": "~2.0.0"
             }
         },
-        "randomatic": {
+        "node_modules/randomatic": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
-            "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
-            },
             "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                }
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
             }
         },
-        "readable-stream": {
+        "node_modules/randomatic/node_modules/is-number": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+            "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/randomatic/node_modules/kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/readable-stream": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
-            "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
-        "regex-cache": {
+        "node_modules/regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
-            "requires": {
-                "is-equal-shallow": "0.1.3"
+            "dependencies": {
+                "is-equal-shallow": "^0.1.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "remove-trailing-separator": {
+        "node_modules/remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
         },
-        "repeat-element": {
+        "node_modules/repeat-element": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
             "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "repeat-string": {
+        "node_modules/repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
         },
-        "replace-ext": {
+        "node_modules/replace-ext": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
             "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
-        "request": {
+        "node_modules/request": {
             "version": "2.87.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
             "dev": true,
-            "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
             }
         },
-        "requires-port": {
+        "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
-        "resolve": {
+        "node_modules/resolve": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
-            "requires": {
-                "path-parse": "1.0.5"
+            "dependencies": {
+                "path-parse": "^1.0.5"
             }
         },
-        "rimraf": {
+        "node_modules/rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
-            "requires": {
-                "glob": "7.1.2"
+            "dependencies": {
+                "glob": "^7.0.5"
+            },
+            "bin": {
+                "rimraf": "bin.js"
             }
         },
-        "safe-buffer": {
+        "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
-        "semver": {
+        "node_modules/semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
             "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-            "dev": true
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
         },
-        "source-map": {
+        "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "source-map-support": {
+        "node_modules/source-map-support": {
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
-            "requires": {
-                "buffer-from": "1.1.0",
-                "source-map": "0.6.1"
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
-        "split": {
+        "node_modules/split": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
-            "requires": {
-                "through": "2.3.8"
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "sprintf-js": {
+        "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "sshpk": {
+        "node_modules/sshpk": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
-            "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "getpass": "^0.1.1"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "optionalDependencies": {
+                "bcrypt-pbkdf": "^1.0.0",
+                "ecc-jsbn": "~0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             }
         },
-        "stat-mode": {
+        "node_modules/stat-mode": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
             "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
             "dev": true
         },
-        "stream-combiner": {
+        "node_modules/stream-combiner": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
-            "requires": {
-                "duplexer": "0.1.1"
+            "dependencies": {
+                "duplexer": "~0.1.1"
             }
         },
-        "stream-shift": {
+        "node_modules/stream-shift": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
         },
-        "streamfilter": {
+        "node_modules/streamfilter": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
+            "dependencies": {
+                "readable-stream": "^2.0.2"
             }
         },
-        "streamifier": {
+        "node_modules/streamifier": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
             "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
         },
-        "string_decoder": {
+        "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.2"
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
             }
         },
-        "strip-ansi": {
+        "node_modules/strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
-            "requires": {
-                "ansi-regex": "2.1.1"
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "strip-bom": {
+        "node_modules/strip-bom": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
-            "requires": {
-                "is-utf8": "0.2.1"
+            "dependencies": {
+                "is-utf8": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "strip-bom-stream": {
+        "node_modules/strip-bom-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
-            "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+            "dependencies": {
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "supports-color": {
+        "node_modules/supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
-        "tar": {
+        "node_modules/tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
-            "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+            "dependencies": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
-        "through": {
+        "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
-        "through2": {
+        "node_modules/through2": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+            "dependencies": {
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
-        "through2-filter": {
+        "node_modules/through2-filter": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
-            "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+            "dependencies": {
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
-        "to-absolute-glob": {
+        "node_modules/to-absolute-glob": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
-            "requires": {
-                "extend-shallow": "2.0.1"
-            },
             "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                }
+                "extend-shallow": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "tough-cookie": {
+        "node_modules/to-absolute-glob/node_modules/extend-shallow": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "dev": true,
+            "dependencies": {
+                "is-extendable": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/tough-cookie": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
-            "requires": {
-                "punycode": "1.4.1"
+            "dependencies": {
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
-        "tslib": {
+        "node_modules/tslib": {
             "version": "1.9.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
             "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
             "dev": true
         },
-        "tslint": {
+        "node_modules/tslint": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
-            "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.15.1",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.12.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.7.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.2",
-                "tsutils": "2.27.1"
+            "dependencies": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.12.1"
+            },
+            "bin": {
+                "tslint": "bin/tslint"
+            },
+            "engines": {
+                "node": ">=4.8.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
             }
         },
-        "tsutils": {
+        "node_modules/tsutils": {
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
-            "requires": {
-                "tslib": "1.9.2"
+            "dependencies": {
+                "tslib": "^1.8.1"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev"
             }
         },
-        "tunnel-agent": {
+        "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.2"
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "tweetnacl": {
+        "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true,
             "optional": true
         },
-        "typescript": {
+        "node_modules/typescript": {
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
             "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
-            "dev": true
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
         },
-        "unique-stream": {
+        "node_modules/unique-stream": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
-            "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+            "dependencies": {
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
-        "url-parse": {
+        "node_modules/url-parse": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
             "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
-            "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+            "dependencies": {
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
-        "util-deprecate": {
+        "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
-        "uuid": {
+        "node_modules/uuid": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
             "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-            "dev": true
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
         },
-        "vali-date": {
+        "node_modules/vali-date": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
             "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "verror": {
+        "node_modules/verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
-        "vinyl": {
+        "node_modules/vinyl": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
-            "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+            "dependencies": {
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
+            },
+            "engines": {
+                "node": ">= 0.9"
             }
         },
-        "vinyl-fs": {
+        "node_modules/vinyl-fs": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
-            "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
-            },
             "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
+                "gulp-sourcemaps": "1.6.0",
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
             }
         },
-        "vinyl-source-stream": {
+        "node_modules/vinyl-fs/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/vinyl-fs/node_modules/replace-ext": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/vinyl-fs/node_modules/vinyl": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
+                "replace-ext": "0.0.1"
+            },
+            "engines": {
+                "node": ">= 0.9"
+            }
+        },
+        "node_modules/vinyl-source-stream": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
-            "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+            "dependencies": {
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
-        "vscode": {
+        "node_modules/vscode": {
             "version": "1.1.18",
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.18.tgz",
             "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
+            "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
             "dev": true,
-            "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+            "dependencies": {
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.87.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
+            },
+            "bin": {
+                "vscode-install": "bin/install"
+            },
+            "engines": {
+                "node": ">=6.4.0"
             }
         },
-        "wrappy": {
+        "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
-        "xtend": {
+        "node_modules/xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.4"
+            }
         },
-        "yauzl": {
+        "node_modules/yauzl": {
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
             "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
             "dev": true,
-            "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
-        "yazl": {
+        "node_modules/yazl": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
-            "requires": {
-                "buffer-crc32": "0.2.13"
+            "dependencies": {
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     },
     "homepage": "https://github.com/ffaraone/vscode-opensslutils/blob/master/README.md",
     "activationEvents": [
+        "onStartupFinished",
         "onCommand:opensslutils.showOpenSSLPreview",
         "onCommand:opensslutils.convertCrtToPem",
         "onCommand:opensslutils.convertPemToCrt",
@@ -44,19 +45,42 @@
                 "title": "OpenSSL Utils configuration",
                 "properties": {
                     "opensslutils.opensslPath": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
+                        "type": "string",
                         "default": null,
                         "description": "Full path to the openssl executable"
                     },
                     "opensslutils.useWsl": {
-                        "type": [
-                            "boolean"
-                        ],
+                        "type": "boolean",
                         "default": false,
                         "description": "Use OpenSSL via Windows Subsystem for Linux"
+                    },
+                    "opensslutils.preview.codeLensEnabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Show automatic OpenSSL CodeLens previews above certificate and CSR blocks."
+                    },
+                    "opensslutils.preview.maxCertificates": {
+                        "type": "number",
+                        "default": 5,
+                        "minimum": 1,
+                        "description": "Maximum number of certificate or CSR blocks to render inline before showing expand actions."
+                    },
+                    "opensslutils.preview.autoLoadInline": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Automatically load inline previews for visible certificate or CSR blocks when the file is small enough."
+                    },
+                    "opensslutils.preview.maxAutoLoadCertificates": {
+                        "type": "number",
+                        "default": 3,
+                        "minimum": 1,
+                        "description": "Maximum number of visible certificate or CSR blocks to auto-load inline."
+                    },
+                    "opensslutils.preview.maxAutoLoadBytes": {
+                        "type": "number",
+                        "default": 131072,
+                        "minimum": 1,
+                        "description": "Maximum document size in bytes for automatic inline preview loading."
                     }
                 }
             }
@@ -129,10 +153,11 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.6",
-        "tslint": "^5.8.0",
+        "@types/mocha": "^2.2.42",
         "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+        "@types/vscode": "^1.23.0",
+        "tslint": "^5.8.0",
+        "typescript": "^2.6.1",
+        "vscode": "^1.1.6"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,9 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.convertPemToCrt', converters.convertPemToCrt));
 	context.subscriptions.push(preview.disposable);
 	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.showOpenSSLPreview', preview.command));
+	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.refreshInlineOpenSSLPreview', preview.refreshInlineCommand));
+	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.expandInlineOpenSSLPreview', preview.expandInlineCommand));
+	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.openInlineOpenSSLPreview', preview.openInlineCommand));
 	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.generatePrivKey', generators.generatePrivKey));
 	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.generateKeyCsr', generators.getKeyCsrGenerator(context.extensionPath)));
 	context.subscriptions.push(vscode.commands.registerCommand('opensslutils.generateSelfSignedCert', generators.getSelfSignedCertGenerator(context.extensionPath)));

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -6,8 +6,94 @@ let currentPreviewDocument: vscode.TextDocument | null = null;
 
 
 const previewUri = vscode.Uri.parse('openssl-preview://authority/OpenSSL%20Preview');
+const inlineDetailPreviewUri = vscode.Uri.parse('openssl-preview://authority/OpenSSL%20Inline%20Preview');
 
 let provider = new OpenSSLTextDocumentContentProvider();
+
+type PreviewKind = 'certificate' | 'csr';
+
+interface PreviewBlock {
+    index: number;
+    startLine: number;
+    endLine: number;
+    text: string;
+    kind: PreviewKind;
+}
+
+interface ParsedInlinePreview {
+    fullText: string;
+    summaryText: string;
+}
+
+interface InlinePreviewState {
+    blocks: PreviewBlock[];
+    expanded: Set<number>;
+    renderedPreviews: Map<number, ParsedInlinePreview>;
+    autoLoaded: Set<number>;
+}
+
+interface PreviewCommandArgs {
+    uri?: string;
+    index?: number;
+}
+
+const inlinePreviewStates = new Map<string, InlinePreviewState>();
+
+const inlineCodeLensEmitter = new vscode.EventEmitter<void>();
+
+const inlineCodeLensProvider: vscode.CodeLensProvider = {
+    onDidChangeCodeLenses: inlineCodeLensEmitter.event,
+    provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+        const state = inlinePreviewStates.get(document.uri.toString());
+        if (!state) {
+            return [];
+        }
+
+        const lenses: vscode.CodeLens[] = [];
+        const maxCertificates = getInlineMaxCertificates();
+
+        state.blocks.forEach(block => {
+            const range = new vscode.Range(block.startLine, 0, block.startLine, 0);
+            const isRendered = block.index < maxCertificates || state.expanded.has(block.index);
+            if (!isRendered) {
+                lenses.push(new vscode.CodeLens(range, {
+                    title: `Show preview`,
+                    command: 'opensslutils.expandInlineOpenSSLPreview',
+                    arguments: [{ uri: document.uri.toString(), index: block.index }]
+                }));
+                return;
+            }
+
+            const parsedPreview = state.renderedPreviews.get(block.index);
+            if (!parsedPreview) {
+                lenses.push(new vscode.CodeLens(range, {
+                    title: 'Load Preview',
+                    command: 'opensslutils.refreshInlineOpenSSLPreview',
+                    arguments: [{ uri: document.uri.toString(), index: block.index }]
+                }));
+                return;
+            }
+
+            lenses.push(new vscode.CodeLens(range, {
+                title: parsedPreview.summaryText,
+                command: 'opensslutils.openInlineOpenSSLPreview',
+                arguments: [{ uri: document.uri.toString(), index: block.index }]
+            }));
+            lenses.push(new vscode.CodeLens(range, {
+                title: `$(refresh) Refresh`,
+                command: 'opensslutils.refreshInlineOpenSSLPreview',
+                arguments: [{ uri: document.uri.toString(), index: block.index }]
+            }));
+            lenses.push(new vscode.CodeLens(range, {
+                title: 'Open Details',
+                command: 'opensslutils.openInlineOpenSSLPreview',
+                arguments: [{ uri: document.uri.toString(), index: block.index }]
+            }));
+        });
+
+        return lenses;
+    }
+};
 
 vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
     if (vscode.window.activeTextEditor && e.document === vscode.window.activeTextEditor.document) {
@@ -20,16 +106,25 @@ vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor | undefined) => 
             return;
         }
         provider.update(previewUri);
+        maybeAutoShowInlinePreview(e);
     }
+});
+vscode.window.onDidChangeTextEditorVisibleRanges((e: vscode.TextEditorVisibleRangesChangeEvent) => {
+    maybeAutoShowInlinePreview(e.textEditor);
 });
 vscode.workspace.onDidCloseTextDocument((e: vscode.TextDocument) => {
     if (e === currentPreviewDocument) {
         currentPreviewDocument = null;
     }
+    if (inlinePreviewStates.has(e.uri.toString())) {
+        inlinePreviewStates.delete(e.uri.toString());
+        inlineCodeLensEmitter.fire();
+    }
 });
 
 
 function previewDocument() {
+    provider.clearContent(previewUri);
     vscode.workspace.openTextDocument(previewUri).then(doc => {
         currentPreviewDocument = doc;
         vscode.window.showTextDocument(doc, {
@@ -42,9 +137,388 @@ function previewDocument() {
     });
 }
 
+function showOpenSSLPreview() {
+    previewDocument();
+}
+
+function showInlinePreview() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active editor');
+        return;
+    }
+
+    renderInlinePreviewForEditor(editor);
+}
+
+function renderInlinePreviewForEditor(editor: vscode.TextEditor) {
+    if (editor.document === currentPreviewDocument) {
+        return;
+    }
+
+    const blocks = extractPreviewBlocks(editor.document.getText());
+    if (!blocks.length) {
+        clearInlinePreview(editor.document.uri);
+        return;
+    }
+
+    const state = getOrCreateInlineState(editor.document.uri.toString(), blocks);
+    state.blocks = blocks;
+    const maxCertificates = getInlineMaxCertificates();
+    const nextRendered = new Map<number, ParsedInlinePreview>();
+    state.renderedPreviews.forEach((value, index) => {
+        if (index < maxCertificates || state.expanded.has(index)) {
+            nextRendered.set(index, value);
+        }
+    });
+    state.renderedPreviews = nextRendered;
+
+    maybeAutoLoadVisibleBlocks(editor, state);
+
+    inlineCodeLensEmitter.fire();
+}
+
+function maybeAutoShowInlinePreview(editor: vscode.TextEditor) {
+    if (!isInlineCodeLensEnabled()) {
+        return;
+    }
+
+    const uri = editor.document.uri.toString();
+    if (inlinePreviewStates.has(uri)) {
+        const state = inlinePreviewStates.get(uri);
+        if (state) {
+            maybeAutoLoadVisibleBlocks(editor, state);
+        }
+        inlineCodeLensEmitter.fire();
+        return;
+    }
+
+    if (!extractPreviewBlocks(editor.document.getText()).length) {
+        return;
+    }
+
+    renderInlinePreviewForEditor(editor);
+}
+
+function refreshInlinePreview(args?: PreviewCommandArgs) {
+    const editor = getTargetEditor(args);
+    if (!editor) {
+        return;
+    }
+
+    const uri = editor.document.uri.toString();
+    const state = inlinePreviewStates.get(uri);
+    if (!state) {
+        showInlinePreview();
+        return;
+    }
+
+    const blocks = extractPreviewBlocks(editor.document.getText());
+    if (!blocks.length) {
+        clearInlinePreview(editor.document.uri);
+        vscode.window.showInformationMessage('Preview not available');
+        return;
+    }
+
+    state.blocks = blocks;
+    if (typeof args !== 'undefined' && typeof args.index === 'number') {
+        const block = findBlock(state.blocks, args.index);
+        if (!block) {
+            return;
+        }
+        const maxCertificates = getInlineMaxCertificates();
+        if (block.index >= maxCertificates && !state.expanded.has(block.index)) {
+            return;
+        }
+        state.renderedPreviews.set(block.index, renderInlinePreview(block));
+    } else {
+        state.renderedPreviews.clear();
+        const maxCertificates = getInlineMaxCertificates();
+        state.blocks.forEach(block => {
+            if (block.index < maxCertificates || state.expanded.has(block.index)) {
+                state.renderedPreviews.set(block.index, renderInlinePreview(block));
+            }
+        });
+    }
+
+    inlineCodeLensEmitter.fire();
+}
+
+function expandInlinePreview(args?: PreviewCommandArgs) {
+    const editor = getTargetEditor(args);
+    if (!editor || typeof args === 'undefined' || typeof args.index !== 'number') {
+        return;
+    }
+
+    const blocks = extractPreviewBlocks(editor.document.getText());
+    if (!blocks.length) {
+        clearInlinePreview(editor.document.uri);
+        return;
+    }
+
+    const state = getOrCreateInlineState(editor.document.uri.toString(), blocks);
+    state.blocks = blocks;
+    state.expanded.add(args.index);
+    const block = findBlock(blocks, args.index);
+    if (!block) {
+        return;
+    }
+
+    state.renderedPreviews.set(block.index, renderInlinePreview(block));
+    inlineCodeLensEmitter.fire();
+}
+
+function openInlinePreview(args?: PreviewCommandArgs) {
+    const editor = getTargetEditor(args);
+    if (!editor || typeof args === 'undefined' || typeof args.index !== 'number') {
+        return;
+    }
+
+    const state = inlinePreviewStates.get(editor.document.uri.toString());
+    if (!state) {
+        return;
+    }
+
+    const parsedPreview = state.renderedPreviews.get(args.index);
+    if (!parsedPreview) {
+        return;
+    }
+
+    provider.setContent(inlineDetailPreviewUri, parsedPreview.fullText);
+    vscode.workspace.openTextDocument(inlineDetailPreviewUri).then(doc => {
+        vscode.window.showTextDocument(doc, {
+            preserveFocus: true,
+            preview: false,
+            viewColumn: vscode.ViewColumn.Two
+        });
+    }, (reason) => {
+        vscode.window.showErrorMessage(reason);
+    });
+}
+
+function isInlineCodeLensEnabled(): boolean {
+    const configured = vscode.workspace.getConfiguration('opensslutils').get('preview.codeLensEnabled');
+    if (typeof configured === 'boolean') {
+        return configured;
+    }
+    return true;
+}
+
+function getInlineMaxCertificates(): number {
+    const configured = vscode.workspace.getConfiguration('opensslutils').get('preview.maxCertificates');
+    if (typeof configured === 'number' && configured > 0) {
+        return configured;
+    }
+    return 5;
+}
+
+function getOrCreateInlineState(uri: string, blocks: PreviewBlock[]): InlinePreviewState {
+    let state = inlinePreviewStates.get(uri);
+    if (!state) {
+        state = {
+            blocks: blocks,
+            expanded: new Set<number>(),
+            renderedPreviews: new Map<number, ParsedInlinePreview>(),
+            autoLoaded: new Set<number>()
+        };
+        inlinePreviewStates.set(uri, state);
+    }
+    return state;
+}
+
+function clearInlinePreview(uri: vscode.Uri) {
+    inlinePreviewStates.delete(uri.toString());
+    inlineCodeLensEmitter.fire();
+}
+
+function getTargetEditor(args?: PreviewCommandArgs): vscode.TextEditor | undefined {
+    if (args && args.uri) {
+        const match = vscode.window.visibleTextEditors.find(editor => editor.document.uri.toString() === args.uri);
+        if (match) {
+            return match;
+        }
+    }
+    return vscode.window.activeTextEditor;
+}
+
+function findBlock(blocks: PreviewBlock[], index: number): PreviewBlock | undefined {
+    return blocks.find(block => block.index === index);
+}
+
+function extractPreviewBlocks(text: string): PreviewBlock[] {
+    const lines = text.split(/\r?\n/);
+    const blocks: PreviewBlock[] = [];
+    let currentStart = -1;
+    let currentKind: PreviewKind | null = null;
+
+    lines.forEach((line, lineIndex) => {
+        const trimmed = line.trim();
+        if (currentKind === null) {
+            if (trimmed === '-----BEGIN CERTIFICATE-----') {
+                currentKind = 'certificate';
+                currentStart = lineIndex;
+            } else if (trimmed === '-----BEGIN CERTIFICATE REQUEST-----' || trimmed === '-----BEGIN NEW CERTIFICATE REQUEST-----') {
+                currentKind = 'csr';
+                currentStart = lineIndex;
+            }
+            return;
+        }
+
+        const isCertificateEnd = currentKind === 'certificate' && trimmed === '-----END CERTIFICATE-----';
+        const isCsrEnd = currentKind === 'csr' && (trimmed === '-----END CERTIFICATE REQUEST-----' || trimmed === '-----END NEW CERTIFICATE REQUEST-----');
+        if (!isCertificateEnd && !isCsrEnd) {
+            return;
+        }
+
+        blocks.push({
+            index: blocks.length,
+            startLine: currentStart,
+            endLine: lineIndex,
+            text: lines.slice(currentStart, lineIndex + 1).join('\n') + '\n',
+            kind: currentKind
+        });
+        currentStart = -1;
+        currentKind = null;
+    });
+
+    return blocks;
+}
+
+function renderInlinePreview(block: PreviewBlock): ParsedInlinePreview {
+    try {
+        const parsed = block.kind === 'certificate' ? provider.parsePemText(block.text) : provider.parseCsrText(block.text);
+        return {
+            fullText: parsed,
+            summaryText: summarizeInlinePreview(parsed, block.kind)
+        };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to parse OpenSSL preview';
+        return {
+            fullText: `OpenSSL Preview Error\n${message}\n`,
+            summaryText: 'OpenSSL Preview Error'
+        };
+    }
+}
+
+function maybeAutoLoadVisibleBlocks(editor: vscode.TextEditor, state: InlinePreviewState) {
+    if (!shouldAutoLoadInline(editor, state)) {
+        return;
+    }
+
+    const visibleRanges = editor.visibleRanges;
+    if (!visibleRanges.length) {
+        return;
+    }
+
+    const maxAutoLoadCertificates = getInlineMaxAutoLoadCertificates();
+    let autoLoadedCount = state.autoLoaded.size;
+    state.blocks.forEach(block => {
+        if (autoLoadedCount >= maxAutoLoadCertificates) {
+            return;
+        }
+        if (block.index >= getInlineMaxCertificates() && !state.expanded.has(block.index)) {
+            return;
+        }
+        if (state.renderedPreviews.has(block.index) || state.autoLoaded.has(block.index)) {
+            return;
+        }
+        if (!isBlockVisible(block, visibleRanges)) {
+            return;
+        }
+
+        state.renderedPreviews.set(block.index, renderInlinePreview(block));
+        state.autoLoaded.add(block.index);
+        autoLoadedCount += 1;
+    });
+}
+
+function shouldAutoLoadInline(editor: vscode.TextEditor, state: InlinePreviewState): boolean {
+    if (!isInlineCodeLensEnabled()) {
+        return false;
+    }
+
+    const configured = vscode.workspace.getConfiguration('opensslutils').get('preview.autoLoadInline');
+    const autoLoadInline = typeof configured === 'boolean' ? configured : true;
+    if (!autoLoadInline) {
+        return false;
+    }
+
+    if (state.blocks.length > getInlineMaxAutoLoadCertificates()) {
+        return false;
+    }
+
+    const maxBytes = getInlineMaxAutoLoadBytes();
+    if (editor.document.getText().length > maxBytes) {
+        return false;
+    }
+
+    return true;
+}
+
+function isBlockVisible(block: PreviewBlock, visibleRanges: readonly vscode.Range[]): boolean {
+    return visibleRanges.some(range => block.startLine <= range.end.line && block.endLine >= range.start.line);
+}
+
+function getInlineMaxAutoLoadCertificates(): number {
+    const configured = vscode.workspace.getConfiguration('opensslutils').get('preview.maxAutoLoadCertificates');
+    if (typeof configured === 'number' && configured > 0) {
+        return configured;
+    }
+    return 3;
+}
+
+function getInlineMaxAutoLoadBytes(): number {
+    const configured = vscode.workspace.getConfiguration('opensslutils').get('preview.maxAutoLoadBytes');
+    if (typeof configured === 'number' && configured > 0) {
+        return configured;
+    }
+    return 131072;
+}
+
+function summarizeInlinePreview(text: string, kind: PreviewKind): string {
+    const subject = matchPreviewField(text, 'Subject:') || 'unknown subject';
+    const issuer = matchPreviewField(text, 'Issuer:') || 'unknown issuer';
+    const notAfter = matchPreviewField(text, 'Not After :') || matchPreviewField(text, 'Not After:') || 'unknown expiry';
+    const label = kind === 'certificate' ? 'Certificate' : 'CSR';
+
+    if (kind === 'csr') {
+        return `${label}: ${truncateSummary(subject)}`;
+    }
+
+    return `${label}: ${truncateSummary(subject)} | Issuer: ${truncateSummary(issuer)} | Expires: ${truncateSummary(notAfter)}`;
+}
+
+function matchPreviewField(text: string, field: string): string | undefined {
+    const escaped = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = text.match(new RegExp(`^\\s*${escaped}\\s*(.+)$`, 'm'));
+    if (!match) {
+        return undefined;
+    }
+    return match[1].trim();
+}
+
+function truncateSummary(text: string): string {
+    if (text.length <= 60) {
+        return text;
+    }
+    return `${text.slice(0, 57)}...`;
+}
+
 const preview = {
-    command: previewDocument,
-    disposable: vscode.Disposable.from(vscode.workspace.registerTextDocumentContentProvider('openssl-preview', provider))
+    command: showOpenSSLPreview,
+    refreshInlineCommand: refreshInlinePreview,
+    expandInlineCommand: expandInlinePreview,
+    openInlineCommand: openInlinePreview,
+    disposable: vscode.Disposable.from(
+        vscode.workspace.registerTextDocumentContentProvider('openssl-preview', provider),
+        vscode.languages.registerCodeLensProvider([{ scheme: 'file' }, { scheme: 'untitled' }], inlineCodeLensProvider)
+    )
 };
+
+setTimeout(() => {
+    if (vscode.window.activeTextEditor && isInlineCodeLensEnabled()) {
+        maybeAutoShowInlinePreview(vscode.window.activeTextEditor);
+    }
+}, 0);
 
 export default preview;

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -4,8 +4,13 @@ import * as vscode from 'vscode';
 
 export class OpenSSLTextDocumentContentProvider implements vscode.TextDocumentContentProvider {
 	private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+        private overrides = new Map<string, string>();
 
 		public provideTextDocumentContent(uri: vscode.Uri): string {
+            const override = this.overrides.get(uri.toString());
+            if (typeof override === 'string') {
+                return override;
+            }
             return this.processDocument();
             
 		}
@@ -18,6 +23,16 @@ export class OpenSSLTextDocumentContentProvider implements vscode.TextDocumentCo
 			this._onDidChange.fire(uri);
 		}
 
+        public setContent(uri: vscode.Uri, content: string) {
+            this.overrides.set(uri.toString(), content);
+            this.update(uri);
+        }
+
+        public clearContent(uri: vscode.Uri) {
+            this.overrides.delete(uri.toString());
+            this.update(uri);
+        }
+
         private processDocument(): string {
             const editor = vscode.window.activeTextEditor;
             if (!editor) {
@@ -25,10 +40,18 @@ export class OpenSSLTextDocumentContentProvider implements vscode.TextDocumentCo
             }
             const text = editor.document.getText().trim();
             if (text.startsWith('-----BEGIN CERTIFICATE-----')) {
-                return openssl.parsePem(text);
+                return this.parsePemText(text);
             } else if (text.startsWith('-----BEGIN CERTIFICATE REQUEST-----') || text.startsWith('-----BEGIN NEW CERTIFICATE REQUEST-----')) {
-                return openssl.parseCsr(text);			
+                return this.parseCsrText(text);			
 			}
             return 'Preview not available';
+        }
+
+        public parsePemText(text: string): string {
+            return openssl.parsePem(text);
+        }
+
+        public parseCsrText(text: string): string {
+            return openssl.parseCsr(text);
         }
 	}


### PR DESCRIPTION

<img width="711" height="143" alt="image" src="https://github.com/user-attachments/assets/f28f51ae-653e-4b33-8073-59d1f6b2e8db" />

## Summary

Add inline OpenSSL previews for PEM certificates and CSRs using CodeLens, while keeping the existing `Show OpenSSL preview` command behavior unchanged.

This gives users a lightweight summary above certificate blocks and a quick path to open the full parsed OpenSSL output without modifying file contents.

## What changed

- add automatic CodeLens previews above PEM certificate and CSR blocks
- add CodeLens actions to:
  - load a preview on demand
  - refresh a parsed preview
  - open full details using the same preview surface as the existing command
- auto-load visible previews only when the file is within configured safety limits, including a default auto-load cap of `3`
- avoid eager parsing for large trust stores or files with many certificates
- add preview settings for CodeLens enablement and auto-load limits
- activate on startup so inline CodeLens can appear without first running a command

## Validation

I attempted `npm run compile`, however the current branch does not compile cleanly in this environment:
  - `src/lib/openssl.ts(96,13): error TS2794: Expected 1 arguments, but got 0.`
  - `src/test/index.ts(13,29): error TS2307: Cannot find module 'vscode/lib/testrunner'`

I have another branch which refactors the build for 2026.  I kept the PRs separate.

**I did NOT version bump.**